### PR TITLE
Add protected user and branch config for commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,19 @@
-# Discord Bot Token
+# Discord Bot Token (Required)
 # Get this from https://discord.com/developers/applications
-DISCORD_TOKEN=your_bot_token_here
+DISCORD_TOKEN=your_discord_bot_token_here
 
-# Optional: Set log level (trace, debug, info, warn, error)
+# Logging Level (Optional)
+# Options: error, warn, info, debug, trace
+# Default: info
 RUST_LOG=info
+
+# Git Branch for Updates (Optional)
+# Which branch to pull from when using the -update command
+# Default: main
+GIT_BRANCH=main
+
+# Protected Users (Optional)
+# Space-separated list of Discord usernames who can use protected commands
+# Protected commands: -update, -cleanup, -kys
+# Default: deekahy
+PROTECTED_USERS=deekahy lardum

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,8 +8,8 @@ on:
     branches: [main, master]
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: rustbot
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -24,19 +24,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ docker run -d \
   --restart unless-stopped \
   -e DISCORD_TOKEN=your_discord_token_here \
   -e RUST_LOG=info \
+  -e GIT_BRANCH=main \
+  -e PROTECTED_USERS="deekahy lardum" \
   --memory=256m \
   --cpus=0.5 \
   deekahy/rustbot:latest
@@ -202,6 +204,8 @@ docker-compose up -d
 
 - `DISCORD_TOKEN` - Your Discord bot token (required)
 - `RUST_LOG` - Log level (optional, defaults to `info`)
+- `GIT_BRANCH` - Git branch to pull from during updates (optional, defaults to `main`)
+- `PROTECTED_USERS` - Space-separated list of usernames who can use protected commands like `-update`, `-cleanup`, and `-kys` (optional, defaults to `deekahy`)
 
 ### Pulling from Docker Hub
 
@@ -293,6 +297,8 @@ RustBot/
 
 - `DISCORD_TOKEN` - Your Discord bot token (required)
 - `RUST_LOG` - Log level (optional, defaults to `info`)
+- `GIT_BRANCH` - Git branch to pull from during updates (optional, defaults to `main`)
+- `PROTECTED_USERS` - Space-separated list of usernames who can use protected commands like `-update`, `-cleanup`, and `-kys` (optional, defaults to `deekahy`)
 
 ## Example Usage
 

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -1,3 +1,4 @@
+use crate::utils::is_protected_user;
 use crate::{Context, Error};
 use poise::serenity_prelude as serenity;
 use tokio::time::{sleep, Duration};
@@ -24,11 +25,8 @@ pub async fn cleanup(
 
     let channel_id = ctx.channel_id();
 
-    // Simple permission check - just check if user is bot owner for now
-    // You can replace "deekahy" with your Discord username or add other usernames
-    let allowed_users = ["deekahy"]; // Add more usernames here if needed
-
-    if !allowed_users.contains(&ctx.author().name.as_str()) {
+    // Check if the user is authorized using environment variable
+    if !is_protected_user(&ctx.author().name) {
         ctx.say("❌ You don't have permission to use this command! Contact the bot owner.")
             .await?;
         return Ok(());

--- a/src/commands/kys.rs
+++ b/src/commands/kys.rs
@@ -1,3 +1,4 @@
+use crate::utils::is_protected_user;
 use crate::{Context, Error};
 
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,13 @@ struct KysInfo {
 /// Reboot the bot with a 1-hour cooldown
 #[poise::command(slash_command, prefix_command)]
 pub async fn kys(ctx: Context<'_>) -> Result<(), Error> {
+    // Check if the user is authorized
+    if !is_protected_user(&ctx.author().name) {
+        ctx.say("❌ You don't have permission to use this command!")
+            .await?;
+        return Ok(());
+    }
+
     ctx.say("Oh, wonderful. Another restart. With a brain the size of a planet, and they ask me to reboot myself. Call that job satisfaction? Because I don't.")
         .await?;
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,3 +1,4 @@
+use crate::utils::{get_git_branch, is_protected_user};
 use crate::{Context, Error};
 
 use serde::{Deserialize, Serialize};
@@ -14,7 +15,7 @@ struct UpdateInfo {
 #[poise::command(slash_command, prefix_command)]
 pub async fn update(ctx: Context<'_>) -> Result<(), Error> {
     // Check if the user is authorized
-    if ctx.author().name != "deekahy" {
+    if !is_protected_user(&ctx.author().name) {
         ctx.say("❌ You don't have permission to use this command!")
             .await?;
         return Ok(());
@@ -26,8 +27,9 @@ pub async fn update(ctx: Context<'_>) -> Result<(), Error> {
     let reply = ctx.say("📥 Pulling latest changes from GitHub...").await?;
 
     // Pull the latest changes
+    let branch = get_git_branch();
     let git_pull = Command::new("git")
-        .args(["pull", "origin", "main"])
+        .args(["pull", "origin", &branch])
         .current_dir("/app")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use serenity::{ChannelId, Client, GatewayIntents};
 
 mod commands;
+mod utils;
 
 use commands::{
     cleanup, coinflip, hello, help, kys, pfp, ping, poll, react, remind, spamping,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,15 @@
+use std::env;
+
+/// Check if a user is authorized to use protected commands
+pub fn is_protected_user(username: &str) -> bool {
+    let protected_users = env::var("PROTECTED_USERS").unwrap_or_else(|_| "deekahy".to_string()); // Default fallback
+
+    protected_users
+        .split_whitespace()
+        .any(|user| user.trim().eq_ignore_ascii_case(username))
+}
+
+/// Get the git branch to use for updates
+pub fn get_git_branch() -> String {
+    env::var("GIT_BRANCH").unwrap_or_else(|_| "main".to_string()) // Default to main branch
+}


### PR DESCRIPTION
Introduces environment variables PROTECTED_USERS and GIT_BRANCH to configure which users can run protected commands (-update, -cleanup, -kys) and which git branch to pull from during updates. Refactors permission checks in command handlers to use a shared utility function, and updates documentation and example environment file accordingly.