### PR TITLE
Defer slash command responses in bonk and hit

### DIFF
--- a/src/commands/bonk.rs
+++ b/src/commands/bonk.rs
@@ -23,6 +23,9 @@ pub async fn bonk(
         }
     };
 
+    // Defer response for slash commands to prevent timeout
+    ctx.defer().await?;
+
     // Send initial "thinking" message
     let thinking_msg = ctx.say("Loading the bonk...").await?;
 

--- a/src/commands/hit.rs
+++ b/src/commands/hit.rs
@@ -23,6 +23,9 @@ pub async fn hit(
         }
     };
 
+    // Defer response for slash commands to prevent timeout
+    ctx.defer().await?;
+
     // Send initial "thinking" message
     let thinking_msg = ctx.say("Loading the gun...").await?;
 


### PR DESCRIPTION
Added ctx.defer().await? to both bonk and hit command handlers to prevent timeout issues when processing slash commands.